### PR TITLE
Add Jest API tests

### DIFF
--- a/cloth-app-server/package.json
+++ b/cloth-app-server/package.json
@@ -73,8 +73,12 @@
     "vary": "^1.1.2"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "start": "node server.js"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
   },
   "keywords": [],
   "author": "",

--- a/cloth-app-server/test/server.test.js
+++ b/cloth-app-server/test/server.test.js
@@ -1,0 +1,44 @@
+const path = require('path');
+const { spawn } = require('child_process');
+const request = require('supertest');
+
+const BASE_URL = 'http://localhost:3000';
+let serverProcess;
+
+beforeAll(done => {
+  serverProcess = spawn('node', [path.join(__dirname, '../server.js')]);
+  serverProcess.stdout.on('data', data => {
+    if (data.toString().includes('Server is running')) {
+      done();
+    }
+  });
+});
+
+afterAll(() => {
+  if (serverProcess) {
+    serverProcess.kill();
+  }
+});
+
+describe('POST /api/add-item', () => {
+  test('stores an item', async () => {
+    const item = { type: 'JestType', color: 'JestColor', tag: 'jest-' + Date.now() };
+    const postRes = await request(BASE_URL)
+      .post('/api/add-item')
+      .send(item);
+
+    expect(postRes.statusCode).toBe(201);
+    expect(postRes.body.item).toMatchObject(item);
+
+    const getRes = await request(BASE_URL).get('/api/items');
+    const found = getRes.body.find(i => i.tag === item.tag);
+    expect(found).toBeDefined();
+  });
+});
+
+describe('GET /api/items', () => {
+  test('returns the stored items', async () => {
+    const res = await request(BASE_URL).get('/api/items');
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest and supertest as dev deps and update test script
- create API integration tests for cloth-app-server

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683f4fad93b883269800ba7b16ac4bdc