### PR TITLE
Enable 8‑column outfit grid

### DIFF
--- a/script.js
+++ b/script.js
@@ -234,11 +234,36 @@ function showOutfitSetPage() {
           Shoes: 'shoes'
         };
 
+        const colorMap = {
+          Hats: 'red',
+          Tops: 'orange',
+          Pants: 'yellow',
+          Shoes: 'green'
+        };
+
+        const catMap = {Hats: [], Tops: [], Pants: [], Shoes: []};
+        items.forEach(it => { if (catMap[it.type]) catMap[it.type].push(it); });
+
+        const ordered = [];
+        let idx = 0;
+        while (true) {
+          let added = false;
+          ['Hats','Tops','Pants','Shoes'].forEach(cat => {
+            for (let i = 0; i < 2; i++) {
+              const arr = catMap[cat];
+              if (arr[idx + i]) { ordered.push(arr[idx + i]); added = true; }
+            }
+          });
+          if (!added) break;
+          idx += 2;
+        }
+
         // 2) For each item, create a small square DIV that is draggable
-        items.forEach(item => {
+        ordered.forEach(item => {
           const div = document.createElement('div');
           div.classList.add('draggable-item');
           div.setAttribute('draggable', 'true');
+          div.style.backgroundColor = colorMap[item.type] || '#eee';
           
           // Store some data to identify the item (e.g. tag, type, color, id)
           div.dataset.id = item.id;

--- a/styles.css
+++ b/styles.css
@@ -14,7 +14,7 @@ body {
   /* Main Mobile Container */
   .mobile-container {
     position: relative;
-    width: min(90vw, 648px);
+    width: min(95vw, 800px);
     height: 100vh;
     background-color: #fff;
     border: 1px solid #ccc;
@@ -252,14 +252,14 @@ body {
     overflow-y: auto;
     border: 1px solid #ccc;
     padding: 10px;
-    display: flex;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: repeat(8, 1fr);
     gap: 10px;
   }
   
   /* Draggable item squares */
   .draggable-item {
-    width: 90px;
+    width: 100%;
     height: 60px;
     border: 1px solid #888;
     background-color: #eee;


### PR DESCRIPTION
## Summary
- enlarge the app container
- show outfit items as 8-column grid
- order items 2×2×2×2 per row and color-code by category

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68447e0e347c83268b3e15c6422086ad